### PR TITLE
In 2016 was denomination in Belarus

### DIFF
--- a/app/src/main/assets/resources/currencies.json
+++ b/app/src/main/assets/resources/currencies.json
@@ -121,9 +121,9 @@
   },
   {
     "name": "Belarussian Ruble",
-    "symbol": "Br.",
-    "code": "BYR",
-    "decimals": 0
+    "symbol": "Br",
+    "code": "BYN",
+    "decimals": 2
   },
   {
     "name": "Belize Dollar",


### PR DESCRIPTION
In July 2016, a new ruble was introduced (ISO 4217 code BYN), at a rate of 1 BYN = 10,000 BYR. Old and new rubles circulated in parallel from July 1 to December 31, 2016.