### PR TITLE
Add shortcut for new transaction

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,8 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+q            <meta-data android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
         <activity android:name=".ui.activity.MainActivity" />
         <activity android:name=".ui.activity.TutorialActivity" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,8 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-q            <meta-data android:name="android.app.shortcuts"
+            <meta-data
+                android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
         </activity>
         <activity android:name=".ui.activity.MainActivity" />

--- a/app/src/main/res/xml-v25/shortcuts.xml
+++ b/app/src/main/res/xml-v25/shortcuts.xml
@@ -1,0 +1,12 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="transaction"
+        android:icon="@drawable/ic_budget_24dp"
+        android:shortcutShortLabel="@string/title_fragment_item_transaction"
+        android:shortcutLongLabel="@string/title_activity_new_transaction">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.oriondev.moneywallet"
+            android:targetClass="com.oriondev.moneywallet.ui.activity.NewEditTransactionActivity"/>
+    </shortcut>
+</shortcuts>

--- a/app/src/main/res/xml-v25/shortcuts.xml
+++ b/app/src/main/res/xml-v25/shortcuts.xml
@@ -1,12 +1,12 @@
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
     <shortcut
-        android:shortcutId="transaction"
         android:icon="@drawable/ic_budget_24dp"
-        android:shortcutShortLabel="@string/title_fragment_item_transaction"
-        android:shortcutLongLabel="@string/title_activity_new_transaction">
+        android:shortcutId="transaction"
+        android:shortcutLongLabel="@string/title_activity_new_transaction"
+        android:shortcutShortLabel="@string/title_fragment_item_transaction">
         <intent
             android:action="android.intent.action.VIEW"
-            android:targetPackage="com.oriondev.moneywallet"
-            android:targetClass="com.oriondev.moneywallet.ui.activity.NewEditTransactionActivity"/>
+            android:targetClass="com.oriondev.moneywallet.ui.activity.NewEditTransactionActivity"
+            android:targetPackage="com.oriondev.moneywallet" />
     </shortcut>
 </shortcuts>


### PR DESCRIPTION
This adds a shortcut like suggested in #35, which can be accessed by long-pressing the app icon and pinned on the homescreen.
I'm not really happy with the icon though, alternative suggestions welcome.
Supported on devices with api-level 25 and above.