### PR TITLE
Different names for debug and release builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            applicationIdSuffix ".dev"
+            debuggable true
+        }
     }
     flavorDimensions "version", "map"
     productFlavors {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -96,17 +96,17 @@
 
         <provider
             android:name=".storage.database.DataContentProvider"
-            android:authorities="com.oriondev.moneywallet.storage.data"
-            android:readPermission="com.oriondev.moneywallet.permission.READ_DATA"
-            android:writePermission="com.oriondev.moneywallet.permission.WRITE_DATA"
+            android:authorities="${applicationId}.storage.data"
+            android:readPermission="${applicationId}.permission.READ_DATA"
+            android:writePermission="${applicationId}.permission.WRITE_DATA"
             android:exported="true" />
         <provider
             android:name=".storage.database.SyncContentProvider"
-            android:authorities="com.oriondev.moneywallet.storage.sync"
+            android:authorities="${applicationId}.storage.sync"
             android:exported="false" />
         <provider
             android:name="android.support.v4.content.FileProvider"
-            android:authorities="com.oriondev.moneywallet.storage.file"
+            android:authorities="${applicationId}.storage.file"
             android:grantUriPermissions="true"
             android:exported="false" >
             <meta-data

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
@@ -36,6 +36,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.content.LocalBroadcastManager;
 
+import com.oriondev.moneywallet.BuildConfig;
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.service.BackupHandlerIntentService;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
@@ -49,7 +50,7 @@ public class DataContentProvider extends ContentProvider {
 
     private static final boolean IS_REMOTE_SYNC_ENABLED = false;
 
-    /*package-local*/ static final String AUTHORITY = "com.oriondev.moneywallet.storage.data";
+    /*package-local*/ static final String AUTHORITY = BuildConfig.APPLICATION_ID + ".storage.data";
 
     public static final Uri CONTENT_CURRENCIES = Uri.parse("content://" + AUTHORITY + "/currencies");
     public static final Uri CONTENT_WALLETS = Uri.parse("content://" + AUTHORITY + "/wallets");


### PR DESCRIPTION
By adding the .dev suffix to the package name of debug builds, we can install the development version next to the release on the same device, which makes tests and development much easier.