### PR TITLE
AndroidManifest.xml: Allow adb backups

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
         android:allowBackup="true"
         android:theme="@style/MoneyWalletAppTheme"
         android:requestLegacyExternalStorage="true"
+        android:fullBackupContent="@xml/backup_rules"
         tools:ignore="GoogleAppIndexingWarning">
         <activity android:name=".ui.activity.LauncherActivity">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,10 +35,9 @@
         android:name=".App"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:allowBackup="false"
+        android:allowBackup="true"
         android:theme="@style/MoneyWalletAppTheme"
         android:requestLegacyExternalStorage="true"
-        tools:replace="android:allowBackup"
         tools:ignore="GoogleAppIndexingWarning">
         <activity android:name=".ui.activity.LauncherActivity">
             <intent-filter>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include domain="root" path="."
+             requireFlags="clientSideEncryption" />
+</full-backup-content>


### PR DESCRIPTION
While the built-in backup functionality is nice, some users don't want to fiddle with every application individually when moving phones.