### PR TITLE
Dark navigation bar color for dark theme

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
@@ -117,6 +117,8 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
     private final static int ID_ACTION_NEW_WALLET = 1;
     private final static int ID_ACTION_MANAGE_WALLET = 2;
 
+    private static boolean themeChanged;
+
     private AccountHeader mAccountHeader;
     private Drawer mDrawer;
 
@@ -128,9 +130,21 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setTheme(ThemeEngine.getTheme().getStyle());
         initializeUi();
         loadUi(savedInstanceState);
         registerReceiver();
+        reopenSettings();
+    }
+
+    /**
+     * If the theme was changed, reopen the settings section
+     */
+    private void reopenSettings() {
+        if (themeChanged) {
+            loadSection(ID_SECTION_SETTING);
+            themeChanged = false;
+        }
     }
 
     /**
@@ -590,6 +604,16 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
     protected void onThemeSetup(ITheme theme) {
         super.onThemeSetup(theme);
         applyNavigationDrawerTheme(theme);
+    }
+
+    @Override
+    public void onThemeChanged(ITheme theme) {
+        themeChanged = true;
+        // Recreate the activity to fully apply the theme
+        finish();
+        overridePendingTransition(0, 0);
+        startActivity(getIntent());
+        overridePendingTransition(0, 0);
     }
 
     private void applyNavigationDrawerTheme(ITheme theme) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ITheme.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ITheme.java
@@ -32,6 +32,8 @@ public interface ITheme {
 
     ThemeEngine.Mode getMode();
 
+    int getStyle();
+
     boolean isDark();
 
     int getTextColorPrimary();

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemeEngine.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemeEngine.java
@@ -27,6 +27,8 @@ import androidx.core.graphics.ColorUtils;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.oriondev.moneywallet.R;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -260,6 +262,21 @@ public class ThemeEngine implements ITheme {
             default:
                 // the stored value has been manually altered
                 return Mode.LIGHT;
+        }
+    }
+
+    @Override
+    public int getStyle() {
+        switch (mPreferences.getInt(MODE, DEFAULT_MODE.getIndex())) {
+            case INDEX_MODE_LIGHT:
+                return R.style.LightTheme;
+            case INDEX_MODE_DARK:
+                return R.style.DarkTheme;
+            case INDEX_MODE_DEEP_DARK:
+                return R.style.DeepDarkTheme;
+            default:
+                // the stored value has been manually altered
+                return R.style.LightTheme;
         }
     }
 

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2018.
+  ~ Copyright (c) 2020.
   ~
   ~ This file is part of MoneyWallet.
   ~
@@ -19,18 +19,10 @@
 
 <resources>
 
-    <!-- Base application theme. -->
-    <style name="MoneyWalletAppTheme" parent="MaterialDrawerTheme.Light.DarkToolbar">
-        <!-- Customize your theme here. -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
-        <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
+    <style name="DarkTheme" parent="MoneyWalletAppTheme">
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:windowLightNavigationBar">false</item>
     </style>
-
-    <style name="LightTheme" parent="MoneyWalletAppTheme"/>
-
-    <style name="DarkTheme" parent="MoneyWalletAppTheme" />
 
     <style name="DeepDarkTheme" parent="DarkTheme" />
 


### PR DESCRIPTION
On some Samsung phones, the default color for the navigation bar is white, which doesn't really make sense together with the dark mode enabled.
Fortunately, this can be easily fixed by applying a style.

As a comparison (before and after the change):
<img src="https://user-images.githubusercontent.com/16596935/84573563-a488f380-ada1-11ea-86bb-25f53ff92c5c.png" alt="before" width="300"/> <img src="https://user-images.githubusercontent.com/16596935/84573565-a783e400-ada1-11ea-8003-d97b0e1395c6.png" alt="before" width="300"/>