### PR TITLE
Changed UZS' symbol from лв to som

### DIFF
--- a/app/src/main/assets/resources/currencies.json
+++ b/app/src/main/assets/resources/currencies.json
@@ -760,7 +760,7 @@
   },
   {
     "name": "Uzbekistan Som",
-    "symbol": "лв",
+    "symbol": "som",
     "code": "UZS",
     "decimals": 0
   },


### PR DESCRIPTION
Uzbekistani som's symbol has never been лв, changed to appropriately named one.