### PR TITLE
[Bugfix] 64.99 gets rounded to 64.98

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,6 +128,7 @@ dependencies {
     osmImplementation 'org.osmdroid:osmdroid-android:6.1.1'
     // test dependencies (local tests)
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:3.6.28'
     // android test dependencies (on-device tests)
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:core:1.2.0'

--- a/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
@@ -21,11 +21,11 @@ package com.oriondev.moneywallet.utils;
 
 import android.os.Bundle;
 
+import androidx.annotation.VisibleForTesting;
+
 import com.oriondev.moneywallet.model.CurrencyUnit;
 
 import java.math.BigDecimal;
-import java.math.MathContext;
-import java.math.RoundingMode;
 
 /**
  * Created by andrea on 31/03/18.
@@ -39,10 +39,12 @@ public class EquationSolver {
 
     private final Controller mController;
 
-    private String mFirstNumber;
+    @VisibleForTesting
+    /*package-local*/ String mFirstNumber;
     private String mSecondNumber;
     private Operation mOperation;
-    private CurrencyUnit mCurrency;
+    @VisibleForTesting
+    /*package-local*/ CurrencyUnit mCurrency;
 
     public EquationSolver(Bundle savedInstanceState, Controller controller) {
         mController = controller;
@@ -177,17 +179,11 @@ public class EquationSolver {
             // Error occurred during calculation
             return 0L;
         }
-        double parsedNumber = parseNumber(mFirstNumber).doubleValue();
-        if (!Double.isInfinite(parsedNumber) && !Double.isNaN(parsedNumber)) {
-            BigDecimal number = new BigDecimal(parsedNumber, MathContext.DECIMAL64);
-            if (mCurrency != null) {
-                BigDecimal multiplier = new BigDecimal(Math.pow(10, mCurrency.getDecimals()));
-                BigDecimal result = number.multiply(multiplier);
-                return result.longValue();
-            }
-            return number.longValue();
+        BigDecimal parsedNumber = parseNumber(mFirstNumber);
+        if (mCurrency != null) {
+            return parsedNumber.movePointRight(mCurrency.getDecimals()).longValue();
         }
-        return 0L;
+        return parsedNumber.longValue();
     }
 
     private BigDecimal parseNumber(String number) {

--- a/app/src/test/java/com/oriondev/moneywallet/utils/EquationSolverTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/utils/EquationSolverTest.java
@@ -1,0 +1,302 @@
+package com.oriondev.moneywallet.utils;
+
+import com.oriondev.moneywallet.model.CurrencyUnit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EquationSolverTest {
+
+    @InjectMocks
+    private EquationSolver equationSolver;
+
+    private void mockCurrencyUnit(int decimals) {
+        equationSolver.mCurrency = new CurrencyUnit("", "", "", decimals);
+    }
+
+    /*
+    Order of tests:
+    For each supported currency based on decimal count:
+    - Test zero value input
+    - Test positive value input with expected number of decimals
+    - Test negative value input with expected number of decimals
+    - Test positive value input with the last decimal missing (except for zero decimal currency)
+    - Test negative value input with the last decimal missing (except for zero decimal currency)
+    - Test positive value input with an extra decimal
+    - Test negative value input with an extra decimal
+     */
+
+    // Zero Decimal Currency
+
+    @Test
+    public void testGetResult_zeroDecimalCurrencyAndZeroValue() {
+        mockCurrencyUnit(0);
+        equationSolver.mFirstNumber = "0";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 0L);
+    }
+
+    @Test
+    public void testGetResult_zeroDecimalCurrencyAndPositiveValue() {
+        mockCurrencyUnit(0);
+        equationSolver.mFirstNumber = "64";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 64L);
+    }
+
+    @Test
+    public void testGetResult_zeroDecimalCurrencyAndNegativeValue() {
+        mockCurrencyUnit(0);
+        equationSolver.mFirstNumber = "-64";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, -64L);
+    }
+
+    @Test
+    public void testGetResult_zeroDecimalCurrencyAndPositiveValueWithExtraDecimal() {
+        mockCurrencyUnit(0);
+        equationSolver.mFirstNumber = "64.9";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 64L);
+    }
+
+    @Test
+    public void testGetResult_zeroDecimalCurrencyAndNegativeValueWithExtraDecimal() {
+        mockCurrencyUnit(0);
+        equationSolver.mFirstNumber = "-64.9";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, -64L);
+    }
+
+    // One Decimal Currency
+
+    @Test
+    public void testGetResult_oneDecimalCurrencyAndZeroValue() {
+        mockCurrencyUnit(1);
+        equationSolver.mFirstNumber = "0";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 0L);
+    }
+
+    @Test
+    public void testGetResult_oneDecimalCurrencyAndPositiveValue() {
+        mockCurrencyUnit(1);
+        equationSolver.mFirstNumber = "64.9";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 649L);
+    }
+
+    @Test
+    public void testGetResult_oneDecimalCurrencyAndNegativeValue() {
+        mockCurrencyUnit(1);
+        equationSolver.mFirstNumber = "-64.9";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, -649L);
+    }
+
+    @Test
+    public void testGetResult_oneDecimalCurrencyAndPositiveValueWithMissingLastDecimal() {
+        mockCurrencyUnit(1);
+        equationSolver.mFirstNumber = "64";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 640L);
+    }
+
+    @Test
+    public void testGetResult_oneDecimalCurrencyAndNegativeValueWithMissingLastDecimal() {
+        mockCurrencyUnit(1);
+        equationSolver.mFirstNumber = "-64";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, -640L);
+    }
+
+    @Test
+    public void testGetResult_oneDecimalCurrencyAndPositiveValueWithExtraDecimal() {
+        mockCurrencyUnit(1);
+        equationSolver.mFirstNumber = "64.99";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 649L);
+    }
+
+    @Test
+    public void testGetResult_oneDecimalCurrencyAndNegativeValueWithExtraDecimal() {
+        mockCurrencyUnit(1);
+        equationSolver.mFirstNumber = "-64.99";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, -649L);
+    }
+
+    // Two Decimal Currency
+
+    @Test
+    public void testGetResult_towDecimalCurrencyAndZeroValue() {
+        mockCurrencyUnit(2);
+        equationSolver.mFirstNumber = "0";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 0L);
+    }
+
+    @Test
+    public void testGetResult_towDecimalCurrencyAndPositiveValue() {
+        mockCurrencyUnit(2);
+        equationSolver.mFirstNumber = "64.99";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 6499L);
+    }
+
+    @Test
+    public void testGetResult_towDecimalCurrencyAndNegativeValue() {
+        mockCurrencyUnit(2);
+        equationSolver.mFirstNumber = "-64.99";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, -6499L);
+    }
+
+    @Test
+    public void testGetResult_towDecimalCurrencyAndPositiveValueWithMissingLastDecimal() {
+        mockCurrencyUnit(2);
+        equationSolver.mFirstNumber = "64.9";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 6490L);
+    }
+
+    @Test
+    public void testGetResult_towDecimalCurrencyAndNegativeValueWithMissingLastDecimal() {
+        mockCurrencyUnit(2);
+        equationSolver.mFirstNumber = "-64.9";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, -6490L);
+    }
+
+    @Test
+    public void testGetResult_towDecimalCurrencyAndPositiveValueWithExtraDecimal() {
+        mockCurrencyUnit(2);
+        equationSolver.mFirstNumber = "64.999";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 6499L);
+    }
+
+    @Test
+    public void testGetResult_towDecimalCurrencyAndNegativeValueWithExtraDecimal() {
+        mockCurrencyUnit(2);
+        equationSolver.mFirstNumber = "-64.999";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, -6499L);
+    }
+
+
+    // Three Decimal Currency
+
+    @Test
+    public void testGetResult_threeDecimalCurrencyAndZeroValue() {
+        mockCurrencyUnit(3);
+        equationSolver.mFirstNumber = "0";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 0L);
+    }
+
+    @Test
+    public void testGetResult_threeDecimalCurrencyAndPositiveValue() {
+        mockCurrencyUnit(3);
+        equationSolver.mFirstNumber = "64.999";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 64999L);
+    }
+
+    @Test
+    public void testGetResult_threeDecimalCurrencyAndNegativeValue() {
+        mockCurrencyUnit(3);
+        equationSolver.mFirstNumber = "-64.999";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, -64999L);
+    }
+
+    @Test
+    public void testGetResult_threeDecimalCurrencyAndPositiveValueWithMissingLastDecimal() {
+        mockCurrencyUnit(3);
+        equationSolver.mFirstNumber = "64.99";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 64990L);
+    }
+
+    @Test
+    public void testGetResult_threeDecimalCurrencyAndNegativeValueWithMissingLastDecimal() {
+        mockCurrencyUnit(3);
+        equationSolver.mFirstNumber = "-64.99";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, -64990L);
+    }
+
+    @Test
+    public void testGetResult_threeDecimalCurrencyAndPositiveValueWithExtraDecimal() {
+        mockCurrencyUnit(3);
+        equationSolver.mFirstNumber = "64.9999";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, 64999L);
+    }
+
+    @Test
+    public void testGetResult_threeDecimalCurrencyAndNegativeValueWithExtraDecimal() {
+        mockCurrencyUnit(3);
+        equationSolver.mFirstNumber = "-64.9999";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(result, -64999L);
+    }
+}


### PR DESCRIPTION
This closes to https://github.com/AndreAle94/moneywallet/issues/159 

The cause of the issue is the conversion from `BigDecimal` to `double` and back to `BigDecimal`.

![precision-issue](https://user-images.githubusercontent.com/11408459/102999009-2fe8fb80-4520-11eb-9af3-e5d3cf9e8925.png)

`BigDecinal` has no concept of `infinity` or `NaN`, so I removed those checks which seem to be leftovers from when the migration to `BigDecimal` was done.

I added some unit tests for various scenarios but let me know if you don't want them in, I'll remove them.

**Note:** JUnit tests are unable to run on Android Studio `4.1` and `4.1.1`, showing this error:
```
JUnit version 3.8 or later expected:
```
The bug is [acknowledged by Google](https://issuetracker.google.com/issues/170328018) and according to [this](https://issuetracker.google.com/issues/170328018#comment26), it will be fixed in `4.1.2`. As a workaround, comment out this line in `build.gradle` (app module):
```
useLibrary 'android.test.runner'
```
... resync, and the tests will run. 

Test method names follow the [AOSP convention](https://source.android.com/setup/contribute/code-style#javatests-style-rules).


**Thank you for your work on this app, I've been using it for a year and it suits my needs perfectly.** 👍🏻 