### PR TITLE
[Bugfix] Additional number precision fixes

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/picker/CurrencyConverterPicker.java
+++ b/app/src/main/java/com/oriondev/moneywallet/picker/CurrencyConverterPicker.java
@@ -31,6 +31,8 @@ import com.oriondev.moneywallet.model.ExchangeRate;
 import com.oriondev.moneywallet.ui.fragment.dialog.CurrencyConverterDialog;
 import com.oriondev.moneywallet.utils.CurrencyManager;
 
+import java.math.BigDecimal;
+
 /**
  * Created by andrea on 15/03/18.
  */
@@ -170,11 +172,11 @@ public class CurrencyConverterPicker extends Fragment implements CurrencyConvert
     }
 
     public long convert(long money) {
-        double divider1 = Math.pow(10, mCurrency1.getDecimals());
-        double divider2 = Math.pow(10, mCurrency2.getDecimals());
-        double money1 = money / divider1;
-        double money2 = mConversionRate * money1;
-        return (long) (money2 * divider2);
+        return new BigDecimal(money)
+                .movePointLeft(mCurrency1.getDecimals())
+                .multiply(new BigDecimal(mConversionRate))
+                .movePointRight(mCurrency2.getDecimals())
+                .longValue();
     }
 
     public void notifyMoneyChanged() {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/CurrencyConverterActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/CurrencyConverterActivity.java
@@ -241,10 +241,11 @@ public class CurrencyConverterActivity extends SinglePanelActivity implements Vi
                 mCurrencyToPicker.getCurrentCurrency()
         );
         if (exchangeRate != null) {
-            BigDecimal bigMoney = new BigDecimal(text);
-            bigMoney = bigMoney.multiply(new BigDecimal(exchangeRate.getRate()));
             CurrencyUnit currencyUnit = mCurrencyToPicker.getCurrentCurrency();
-            long money = (long) (bigMoney.doubleValue() * Math.pow(10, currencyUnit.getDecimals()));
+            long money = new BigDecimal(text)
+                    .multiply(BigDecimal.valueOf(exchangeRate.getRate()))
+                    .movePointRight(currencyUnit.getDecimals())
+                    .longValue();
             mTextMoneyTo.setText(mMoneyFormatter.getNotTintedString(currencyUnit, money, MoneyFormatter.CurrencyMode.ALWAYS_HIDDEN));
         } else {
             mTextMoneyTo.setText(R.string.hint_unknown);


### PR DESCRIPTION
Although [the fix from a year ago](https://github.com/AndreAle94/moneywallet/pull/164) got rid of the `EquationSolver` precision rounding error (which appeared when entering expenses through the calculator screen), I recently found 2 more cases when the precision is off.

https://github.com/AndreAle94/moneywallet/commit/57764c4d24d618d4003e6818cc2390467f0f84b6 handles the transaction linked to a transfer issue, also mentioned by other users:
https://github.com/AndreAle94/moneywallet/issues/45#issuecomment-892523865
https://github.com/AndreAle94/moneywallet/issues/45#issuecomment-920913002
https://github.com/AndreAle94/moneywallet/issues/205#issue-1007031441
https://github.com/AndreAle94/moneywallet/issues/205#issuecomment-946909706

https://github.com/AndreAle94/moneywallet/commit/2d604a6413254e6fe004f56e4d027beecde5fdd2 fixes a Currency Convertor rounding error. I haven't seen it mentioned yet. The easiest way to see it is to attempt to convert $19.99 to $ -> see attached screenshot.
![exchange-fix](https://user-images.githubusercontent.com/11408459/140299372-dbbe459b-b7f9-4778-8a90-d29574bb8bbc.png)

@AndreAle94 Is it at all possible to have the app updated on the Google Play Store as well? The latest version there is still v4.0.5.8, which doesn't include last year's precision fix for the Calculator. Unfortunately, I'm stuck with that version because I don't want to lose Dropbox integration for backups. 