### PR TITLE
[Bugfix] Content is displayed under the app bar for w600dp layout

### DIFF
--- a/app/src/main/res/layout-w600dp/fragment_multi_panel_appbar.xml
+++ b/app/src/main/res/layout-w600dp/fragment_multi_panel_appbar.xml
@@ -28,12 +28,14 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/primary_panel_constraint_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical" >
+        android:layout_height="match_parent">
 
         <com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout
             android:id="@+id/primary_app_bar_container"
-            android:layout_width="match_parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:theme_backgroundColor="colorPrimary" >
 
@@ -53,7 +55,7 @@
         <com.oriondev.moneywallet.ui.view.theme.ThemedForegroundCardView
             android:id="@+id/primary_panel_body_container_card_view"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:layout_marginLeft="@dimen/layout_multi_panel_primary_panel_margin_left"
             android:layout_marginRight="@dimen/layout_multi_panel_primary_panel_margin_right"
             android:layout_marginStart="@dimen/layout_multi_panel_primary_panel_margin_left"


### PR DESCRIPTION
Fixes https://github.com/AndreAle94/moneywallet/issues/207

Before:
https://user-images.githubusercontent.com/11408459/140419578-4e91b2c4-5a4e-462d-931a-cc3c326c5db4.mp4

After:
https://user-images.githubusercontent.com/11408459/140419633-dc72f924-63a3-4d4f-9a24-5222599a11e0.mp4

Multiple screens were affected by this issue, including Transfers, Categories and Recurrences to name a few.
This layout is normally used by tablets in portrait mode, but also by phones in landscape mode.

Video captured on Samsung Galaxy Tab A7 10.4"

